### PR TITLE
fix: upgrade upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Configure Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: '.'
       - name: Deploy to Pages


### PR DESCRIPTION
## Summary
- use latest upload-pages-artifact action to avoid deprecated upload-artifact v3

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cd494b2c8333bfcd3cfb107523fd