### PR TITLE
Add music transcriber demo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,7 @@
 
 This repository contains a simple static website showcasing stringed instruments often used by folk singers. Open `index.html` in a browser to view the site.
 
+A basic music transcriber demo is available at `transcribe.html`. The demo lets you upload or record audio, experiment with a sample musical score, and play it back. Actual audio-to-score transcription is not implemented.
+
 
 After pushes to `main`, a GitHub Actions workflow publishes the site to GitHub Pages. Once the workflow succeeds and Pages is enabled in the repository settings, you can preview the site at `https://<github-username>.github.io/ai-sandbox/`.

--- a/index.html
+++ b/index.html
@@ -9,6 +9,9 @@
   <header>
     <h1>Folk Stringed Instruments</h1>
     <p>These stringed instruments are commonly played by folk singers around the world.</p>
+    <nav>
+      <a href="transcribe.html">Music Transcriber</a>
+    </nav>
   </header>
   <main>
     <section>

--- a/transcribe.html
+++ b/transcribe.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Music Transcriber</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/abcjs@6.2.2/dist/abcjs-basic-min.js"></script>
+</head>
+<body>
+  <header>
+    <h1>Music Transcriber</h1>
+  </header>
+  <main>
+    <section>
+      <h2>Audio Input</h2>
+      <input type="file" id="audioFile" accept="audio/*" />
+      <button id="recordBtn">Record</button>
+      <button id="stopBtn" disabled>Stop</button>
+      <audio id="audioPlayback" controls></audio>
+    </section>
+    <section>
+      <h2>Score</h2>
+      <div id="notation"></div>
+      <textarea id="abcInput" rows="8"></textarea>
+      <div>
+        <button id="renderBtn">Render Score</button>
+        <button id="playBtn">Play Score</button>
+      </div>
+    </section>
+  </main>
+  <script src="transcribe.js"></script>
+</body>
+</html>

--- a/transcribe.js
+++ b/transcribe.js
@@ -1,0 +1,65 @@
+let abcText = `X:1\nT:Sample\nM:4/4\nL:1/4\nK:C\nCDEF GABc|cBAG FEDC|`;
+
+const abcInput = document.getElementById('abcInput');
+const notation = document.getElementById('notation');
+abcInput.value = abcText;
+ABCJS.renderAbc('notation', abcText);
+
+// Render score when edited
+const render = () => {
+  abcText = abcInput.value;
+  ABCJS.renderAbc('notation', abcText);
+};
+
+document.getElementById('renderBtn').addEventListener('click', render);
+
+// Play score using abcjs synthesizer
+const playBtn = document.getElementById('playBtn');
+playBtn.addEventListener('click', () => {
+  const visualObj = ABCJS.renderAbc('notation', abcText)[0];
+  const synth = new ABCJS.synth.CreateSynth();
+  synth
+    .init({ visualObj })
+    .then(() => synth.prime())
+    .then(() => synth.start())
+    .catch((err) => console.warn('Playback error', err));
+});
+
+// Handle audio file upload (placeholder for transcription)
+document.getElementById('audioFile').addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const url = URL.createObjectURL(file);
+  document.getElementById('audioPlayback').src = url;
+  // Transcription from audio to score is not implemented; sample score is used.
+});
+
+// Microphone recording
+let mediaRecorder;
+let chunks = [];
+
+const recordBtn = document.getElementById('recordBtn');
+const stopBtn = document.getElementById('stopBtn');
+
+recordBtn.addEventListener('click', async () => {
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  mediaRecorder = new MediaRecorder(stream);
+  mediaRecorder.start();
+  recordBtn.disabled = true;
+  stopBtn.disabled = false;
+  mediaRecorder.ondataavailable = (e) => chunks.push(e.data);
+  mediaRecorder.onstop = () => {
+    const blob = new Blob(chunks, { type: 'audio/webm' });
+    chunks = [];
+    const url = URL.createObjectURL(blob);
+    document.getElementById('audioPlayback').src = url;
+  };
+});
+
+stopBtn.addEventListener('click', () => {
+  if (mediaRecorder) {
+    mediaRecorder.stop();
+    recordBtn.disabled = false;
+    stopBtn.disabled = true;
+  }
+});


### PR DESCRIPTION
## Summary
- add `transcribe.html` demo page with audio upload/recording and editable sample musical score using abcjs
- link the new transcriber from the homepage and document it in README

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cd3925f48333966801260d0258ac