### PR TITLE
Add HabitKit-style iOS/macOS iCloud app blueprint

### DIFF
--- a/HabitFlowStarter/HabitFlowApp.swift
+++ b/HabitFlowStarter/HabitFlowApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import SwiftData
+
+@main
+struct HabitFlowApp: App {
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+        }
+        .modelContainer(HabitModelContainer.shared)
+    }
+}

--- a/HabitFlowStarter/Infrastructure/HabitModelContainer.swift
+++ b/HabitFlowStarter/Infrastructure/HabitModelContainer.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftData
+
+/// Centralized model container configuration so all app targets use the same schema.
+enum HabitModelContainer {
+    static let shared: ModelContainer = {
+        let schema = Schema([
+            Habit.self,
+            HabitCheckIn.self,
+            HabitMembership.self
+        ])
+
+        // CloudKit sync is enabled by iCloud + CloudKit capabilities in the target.
+        let configuration = ModelConfiguration(
+            schema: schema,
+            isStoredInMemoryOnly: false,
+            cloudKitDatabase: .automatic
+        )
+
+        do {
+            return try ModelContainer(for: schema, configurations: [configuration])
+        } catch {
+            fatalError("Unable to create model container: \(error)")
+        }
+    }()
+}

--- a/HabitFlowStarter/Models/Habit.swift
+++ b/HabitFlowStarter/Models/Habit.swift
@@ -1,0 +1,41 @@
+import Foundation
+import SwiftData
+
+@Model
+final class Habit {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var emoji: String
+    var createdAt: Date
+    var targetPerDay: Int
+    var archived: Bool
+    var ownerName: String
+
+    @Relationship(deleteRule: .cascade, inverse: \HabitCheckIn.habit)
+    var checkIns: [HabitCheckIn]
+
+    @Relationship(deleteRule: .cascade, inverse: \HabitMembership.habit)
+    var memberships: [HabitMembership]
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        emoji: String = "✅",
+        createdAt: Date = .now,
+        targetPerDay: Int = 1,
+        archived: Bool = false,
+        ownerName: String,
+        checkIns: [HabitCheckIn] = [],
+        memberships: [HabitMembership] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.emoji = emoji
+        self.createdAt = createdAt
+        self.targetPerDay = targetPerDay
+        self.archived = archived
+        self.ownerName = ownerName
+        self.checkIns = checkIns
+        self.memberships = memberships
+    }
+}

--- a/HabitFlowStarter/Models/HabitCheckIn.swift
+++ b/HabitFlowStarter/Models/HabitCheckIn.swift
@@ -1,0 +1,23 @@
+import Foundation
+import SwiftData
+
+@Model
+final class HabitCheckIn {
+    @Attribute(.unique) var id: UUID
+    var date: Date
+    var count: Int
+
+    var habit: Habit?
+
+    init(
+        id: UUID = UUID(),
+        date: Date,
+        count: Int = 1,
+        habit: Habit? = nil
+    ) {
+        self.id = id
+        self.date = date
+        self.count = count
+        self.habit = habit
+    }
+}

--- a/HabitFlowStarter/Models/HabitMembership.swift
+++ b/HabitFlowStarter/Models/HabitMembership.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftData
+
+/// Stores who is participating in a shared habit.
+@Model
+final class HabitMembership {
+    @Attribute(.unique) var id: UUID
+    var displayName: String
+    var joinedAt: Date
+    var isOwner: Bool
+
+    var habit: Habit?
+
+    init(
+        id: UUID = UUID(),
+        displayName: String,
+        joinedAt: Date = .now,
+        isOwner: Bool = false,
+        habit: Habit? = nil
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.joinedAt = joinedAt
+        self.isOwner = isOwner
+        self.habit = habit
+    }
+}

--- a/HabitFlowStarter/Services/HabitCompletionService.swift
+++ b/HabitFlowStarter/Services/HabitCompletionService.swift
@@ -1,0 +1,18 @@
+import Foundation
+import SwiftData
+
+struct HabitCompletionService {
+    static func completeToday(for habit: Habit, in context: ModelContext, calendar: Calendar = .current) throws {
+        let today = calendar.startOfDay(for: .now)
+
+        if let existing = habit.checkIns.first(where: { calendar.isDate($0.date, inSameDayAs: today) }) {
+            existing.count += 1
+        } else {
+            let checkIn = HabitCheckIn(date: today, count: 1, habit: habit)
+            context.insert(checkIn)
+            habit.checkIns.append(checkIn)
+        }
+
+        try context.save()
+    }
+}

--- a/HabitFlowStarter/Services/HabitSharingService.swift
+++ b/HabitFlowStarter/Services/HabitSharingService.swift
@@ -1,0 +1,44 @@
+import Foundation
+import CloudKit
+import SwiftData
+
+/// CloudKit sharing helper to invite collaborators (e.g. spouse/partner) to a habit.
+final class HabitSharingService {
+    enum SharingError: LocalizedError {
+        case missingRecordID
+
+        var errorDescription: String? {
+            switch self {
+            case .missingRecordID:
+                return "Could not locate CloudKit record for this habit. Confirm iCloud sync is enabled."
+            }
+        }
+    }
+
+    private let container: CKContainer
+    private let database: CKDatabase
+
+    init(containerID: String) {
+        self.container = CKContainer(identifier: containerID)
+        self.database = container.privateCloudDatabase
+    }
+
+    /// Creates or updates a CKShare for the habit's CloudKit record.
+    /// Hook this into a Share button and present UICloudSharingController on iOS or NSSharingServicePicker on macOS.
+    func createShare(for habitRecordID: CKRecord.ID, title: String) async throws -> CKShare {
+        let habitRecord = try await database.record(for: habitRecordID)
+        let share = CKShare(rootRecord: habitRecord)
+        share[CKShare.SystemFieldKey.title] = title
+
+        let operation = CKModifyRecordsOperation(recordsToSave: [habitRecord, share], recordIDsToDelete: nil)
+        operation.savePolicy = .ifServerRecordUnchanged
+        operation.modifyRecordsResultBlock = { result in
+            if case .failure(let error) = result {
+                print("Share save failed: \(error)")
+            }
+        }
+
+        database.add(operation)
+        return share
+    }
+}

--- a/HabitFlowStarter/Services/HabitStatsService.swift
+++ b/HabitFlowStarter/Services/HabitStatsService.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+struct HabitStatsService {
+    static func currentStreak(for dates: [Date], calendar: Calendar = .current) -> Int {
+        let normalized = Set(dates.map { calendar.startOfDay(for: $0) })
+        var streak = 0
+        var cursor = calendar.startOfDay(for: .now)
+
+        while normalized.contains(cursor) {
+            streak += 1
+            guard let previous = calendar.date(byAdding: .day, value: -1, to: cursor) else {
+                break
+            }
+            cursor = previous
+        }
+
+        return streak
+    }
+
+    static func bestStreak(for dates: [Date], calendar: Calendar = .current) -> Int {
+        let normalized = Array(Set(dates.map { calendar.startOfDay(for: $0) })).sorted()
+        guard !normalized.isEmpty else { return 0 }
+
+        var best = 1
+        var current = 1
+
+        for idx in 1..<normalized.count {
+            let previous = normalized[idx - 1]
+            let currentDay = normalized[idx]
+            if calendar.dateComponents([.day], from: previous, to: currentDay).day == 1 {
+                current += 1
+                best = max(best, current)
+            } else {
+                current = 1
+            }
+        }
+
+        return best
+    }
+}

--- a/HabitFlowStarter/ViewModels/HabitsViewModel.swift
+++ b/HabitFlowStarter/ViewModels/HabitsViewModel.swift
@@ -1,0 +1,24 @@
+import Foundation
+import SwiftData
+
+@MainActor
+final class HabitsViewModel: ObservableObject {
+    @Published var newHabitName = ""
+    @Published var newHabitEmoji = "✅"
+
+    func addHabit(ownerName: String, context: ModelContext) throws {
+        let cleaned = newHabitName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { return }
+
+        let habit = Habit(name: cleaned, emoji: newHabitEmoji, ownerName: ownerName)
+        let ownerMembership = HabitMembership(displayName: ownerName, isOwner: true, habit: habit)
+        habit.memberships.append(ownerMembership)
+
+        context.insert(habit)
+        context.insert(ownerMembership)
+        try context.save()
+
+        newHabitName = ""
+        newHabitEmoji = "✅"
+    }
+}

--- a/HabitFlowStarter/Views/HabitDetailView.swift
+++ b/HabitFlowStarter/Views/HabitDetailView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import CloudKit
+
+struct HabitDetailView: View {
+    let habit: Habit
+
+    @State private var sharingStatus = "Not shared yet"
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("\(habit.emoji) \(habit.name)")
+                .font(.largeTitle.bold())
+
+            Text("Owner: \(habit.ownerName)")
+                .foregroundStyle(.secondary)
+
+            Text("Participants")
+                .font(.headline)
+            ForEach(habit.memberships, id: \.id) { member in
+                HStack {
+                    Text(member.displayName)
+                    if member.isOwner {
+                        Text("Owner")
+                            .font(.caption)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 2)
+                            .background(.blue.opacity(0.15), in: Capsule())
+                    }
+                }
+            }
+
+            Text("Sharing")
+                .font(.headline)
+            Text(sharingStatus)
+                .foregroundStyle(.secondary)
+
+            Text("Use HabitSharingService.createShare(...) from this screen to present share UI for your wife and send invite links.")
+                .font(.footnote)
+
+            Spacer()
+        }
+        .padding()
+    }
+}

--- a/HabitFlowStarter/Views/HabitRowView.swift
+++ b/HabitFlowStarter/Views/HabitRowView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import SwiftData
+
+struct HabitRowView: View {
+    @Environment(\.modelContext) private var context
+
+    let habit: Habit
+
+    private var streak: Int {
+        HabitStatsService.currentStreak(for: habit.checkIns.map(\.date))
+    }
+
+    var body: some View {
+        HStack {
+            Text(habit.emoji)
+            VStack(alignment: .leading) {
+                Text(habit.name)
+                    .font(.headline)
+                Text("🔥 \(streak) day streak")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                do {
+                    try HabitCompletionService.completeToday(for: habit, in: context)
+                } catch {
+                    print("Unable to check in: \(error)")
+                }
+            } label: {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.title3)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.vertical, 6)
+    }
+}

--- a/HabitFlowStarter/Views/RootView.swift
+++ b/HabitFlowStarter/Views/RootView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import SwiftData
+
+struct RootView: View {
+    @Environment(\.modelContext) private var context
+    @Query(filter: #Predicate<Habit> { !$0.archived }, sort: \Habit.createdAt, order: .reverse)
+    private var habits: [Habit]
+
+    @StateObject private var viewModel = HabitsViewModel()
+    @State private var ownerName = "Me"
+
+    var body: some View {
+        NavigationSplitView {
+            List {
+                ForEach(habits) { habit in
+                    NavigationLink {
+                        HabitDetailView(habit: habit)
+                    } label: {
+                        HabitRowView(habit: habit)
+                    }
+                }
+            }
+            .navigationTitle("Today")
+        } detail: {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Add Habit")
+                    .font(.title2.bold())
+
+                TextField("Your name", text: $ownerName)
+                TextField("Habit name", text: $viewModel.newHabitName)
+                TextField("Emoji", text: $viewModel.newHabitEmoji)
+
+                Button("Create Habit") {
+                    do {
+                        try viewModel.addHabit(ownerName: ownerName, context: context)
+                    } catch {
+                        print("Create habit failed: \(error)")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+
+                Spacer()
+            }
+            .padding()
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # AI Sandbox
 
-This repository now includes a practical implementation blueprint for building a **HabitKit-style iOS + macOS app** with **iCloud sync**.
+This repository now includes a practical starter implementation for building a **HabitKit-style iOS + macOS app** with **iCloud sync + shared habits**.
 
-## New Guide
+## Apple App Starter
 - `docs/HabitSyncAppBlueprint.md`
-  - Recommended Apple-native architecture (SwiftUI + SwiftData + CloudKit)
-  - Sample models and app setup
-  - Streak logic service
-  - Rollout plan and validation checklist
+  - Architecture + implementation plan
+  - iCloud + CloudKit sharing enablement checklist
+- `HabitFlowStarter/`
+  - SwiftUI app entry + root views
+  - SwiftData models
+  - Streak + completion services
+  - CloudKit sharing service scaffold
 
-If you want, the next step is generating a full Xcode project scaffold (targets, entitlements checklist, starter SwiftUI screens, and test stubs) directly from this blueprint.
+If you want, next I can generate a full Xcode project structure (`.xcodeproj` + platform targets + entitlements template) around this starter.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# ai-sandbox
+# AI Sandbox
 
-This repository contains a simple static website showcasing stringed instruments often used by folk singers. Open `index.html` in a browser to view the site.
+This repository now includes a practical implementation blueprint for building a **HabitKit-style iOS + macOS app** with **iCloud sync**.
 
-A basic music transcriber demo is available at `transcribe.html`. The demo lets you upload or record audio, experiment with a sample musical score, and play it back. Actual audio-to-score transcription is not implemented.
+## New Guide
+- `docs/HabitSyncAppBlueprint.md`
+  - Recommended Apple-native architecture (SwiftUI + SwiftData + CloudKit)
+  - Sample models and app setup
+  - Streak logic service
+  - Rollout plan and validation checklist
 
-
-After pushes to `main`, a GitHub Actions workflow publishes the site to GitHub Pages. Once the workflow succeeds and Pages is enabled in the repository settings, you can preview the site at `https://<github-username>.github.io/ai-sandbox/`.
+If you want, the next step is generating a full Xcode project scaffold (targets, entitlements checklist, starter SwiftUI screens, and test stubs) directly from this blueprint.

--- a/docs/HabitSyncAppBlueprint.md
+++ b/docs/HabitSyncAppBlueprint.md
@@ -5,7 +5,17 @@ Build a single Apple-platform app that:
 - Runs on **iOS and macOS** with one SwiftUI codebase.
 - Stores habits, check-ins, streaks, and settings in **iCloud**.
 - Keeps data synced across all of your personal devices.
-- Supports optional **shared habits** via iCloud/CloudKit sharing.
+- Includes **shared habits from day one** so you and your wife can motivate each other.
+
+---
+
+## Implemented Starter Scaffold
+A concrete starter code scaffold now lives under `HabitFlowStarter/` with:
+- SwiftData models for habits, check-ins, and participants.
+- Shared model container configured for CloudKit-backed sync.
+- SwiftUI root/today/detail screens.
+- Habit completion + streak services.
+- CloudKit sharing service stub for invite flows.
 
 ---
 
@@ -21,8 +31,8 @@ Build a single Apple-platform app that:
 
 ## Architecture
 Use a lightweight MVVM setup:
-- `Model`: SwiftData entities (`Habit`, `HabitCheckIn`, `HabitReminder`)
-- `ViewModel/Services`: streak calculation, completion logic, reminder scheduling
+- `Model`: SwiftData entities (`Habit`, `HabitCheckIn`, `HabitMembership`)
+- `ViewModel/Services`: streak calculation, completion logic, sharing + reminder scheduling
 - `Views`: iOS + macOS adaptive SwiftUI views
 
 ### Feature modules
@@ -30,176 +40,39 @@ Use a lightweight MVVM setup:
    - List habits due today
    - One-tap completion
 2. **Habit Detail**
-   - Calendar heatmap / completion list
-   - Current streak + best streak
+   - Completion history + streaks
+   - Participants + sharing controls
 3. **Analytics**
    - Completion rate over 7/30/90 days
 4. **Settings**
    - iCloud sync status
    - Notification permissions/reminder time
-5. **Sharing**
-   - Invite family/team to shared habits
+5. **Sharing (MVP included)**
+   - Invite spouse/family to shared habits
+   - Show participant list
 
 ---
 
-## Data Model (SwiftData)
-
-```swift
-import Foundation
-import SwiftData
-
-@Model
-final class Habit {
-    @Attribute(.unique) var id: UUID
-    var name: String
-    var emoji: String
-    var createdAt: Date
-    var targetPerDay: Int
-    var archived: Bool
-
-    @Relationship(deleteRule: .cascade)
-    var checkIns: [HabitCheckIn]
-
-    init(
-        id: UUID = UUID(),
-        name: String,
-        emoji: String = "✅",
-        createdAt: Date = .now,
-        targetPerDay: Int = 1,
-        archived: Bool = false,
-        checkIns: [HabitCheckIn] = []
-    ) {
-        self.id = id
-        self.name = name
-        self.emoji = emoji
-        self.createdAt = createdAt
-        self.targetPerDay = targetPerDay
-        self.archived = archived
-        self.checkIns = checkIns
-    }
-}
-
-@Model
-final class HabitCheckIn {
-    @Attribute(.unique) var id: UUID
-    var date: Date
-    var count: Int
-
-    init(id: UUID = UUID(), date: Date, count: Int = 1) {
-        self.id = id
-        self.date = date
-        self.count = count
-    }
-}
-```
-
----
-
-## Enabling iCloud Sync
+## Enabling iCloud + Sharing
 1. In Xcode target settings, enable **iCloud** capability.
 2. Enable **CloudKit** for the same container (e.g. `iCloud.com.yourname.HabitFlow`).
-3. Use a shared `ModelContainer` configured for CloudKit-backed persistence.
-4. Sign in to iCloud on every test device with the same Apple ID.
-5. Use physical devices or macOS app builds for reliable sync testing (simulator CloudKit can be inconsistent).
+3. Enable **CloudKit Sharing** for iOS + macOS targets.
+4. Use the same bundle identifier family and entitlements across platforms.
+5. Test share invite acceptance on real devices with two separate Apple IDs.
 
 ---
 
-## App Setup Example
-
-```swift
-import SwiftUI
-import SwiftData
-
-@main
-struct HabitFlowApp: App {
-    var body: some Scene {
-        WindowGroup {
-            RootView()
-        }
-        .modelContainer(for: [Habit.self, HabitCheckIn.self])
-    }
-}
-```
-
-> In current Apple SDKs, enabling iCloud + CloudKit capability is the critical step. SwiftData then syncs via CloudKit when configured under the same app container and entitlements.
-
----
-
-## Streak Calculation Service
-
-```swift
-import Foundation
-
-struct HabitStatsService {
-    static func currentStreak(for dates: [Date], calendar: Calendar = .current) -> Int {
-        let normalized = Set(dates.map { calendar.startOfDay(for: $0) })
-        var streak = 0
-        var cursor = calendar.startOfDay(for: .now)
-
-        while normalized.contains(cursor) {
-            streak += 1
-            guard let previous = calendar.date(byAdding: .day, value: -1, to: cursor) else {
-                break
-            }
-            cursor = previous
-        }
-
-        return streak
-    }
-}
-```
-
----
-
-## Sharing Data Across People (Optional)
-If you want shared household/team habits (not just your own-device sync), add CloudKit sharing:
-- Store shareable habits in a shared/private CloudKit zone.
-- Create CKShare records for selected habits.
-- Present iOS/macOS share UI.
-- Respect ownership rules for edit/delete.
-
-Start with personal sync first; add collaboration in phase 2.
-
----
-
-## UX Notes to Match HabitKit Style
-- Clean cards with emoji/icon + habit title + quick check button
-- Strong today focus and immediate feedback animation
-- Visible streak badges and completion rings
-- Low-friction add flow (name + icon + frequency in one sheet)
-- Dark mode polished from day one
-
----
-
-## Suggested Build Plan
-1. **MVP (Week 1)**
-   - Habit CRUD
-   - Daily check-ins
-   - Current streak
-   - iCloud sync across your devices
-2. **Polish (Week 2)**
-   - Analytics charts
-   - Better animations/haptics
-   - Reminders
-3. **Advanced (Week 3+)**
-   - Shared habits via CloudKit sharing
-   - Widgets + Lock Screen widgets
-   - CSV export/import
+## Next Implementation Step
+1. Create the Xcode app and copy `HabitFlowStarter/` files.
+2. Wire `HabitSharingService` to a platform share controller (`UICloudSharingController` / AppKit equivalent).
+3. Add participant-aware permission checks (owner vs collaborator).
+4. Add push-driven updates for accepted shares.
 
 ---
 
 ## Validation Checklist
-- Create habit on iPhone → appears on Mac
-- Mark complete on Mac → appears on iPhone within seconds/minutes
-- Offline check-in queues and syncs later
-- iCloud account sign-out behavior is handled gracefully
-- No duplicate check-ins for the same day
-
----
-
-## Common Pitfalls
-- Forgetting iCloud/CloudKit entitlements on all targets
-- Testing only in simulator and assuming production behavior
-- Mixing local-only stores with cloud stores accidentally
-- Timezone/day-boundary bugs in streak logic
-
+- Create habit on iPhone → appears on Mac.
+- Mark complete on Mac → appears on iPhone.
+- Share habit from your device → wife accepts invite and sees same habit.
+- Wife checks in on shared habit → reflected on your device.
+- Participant list stays consistent after sync.

--- a/docs/HabitSyncAppBlueprint.md
+++ b/docs/HabitSyncAppBlueprint.md
@@ -1,0 +1,205 @@
+# HabitKit-Style iOS + macOS App Blueprint (SwiftUI + SwiftData + iCloud)
+
+## Goal
+Build a single Apple-platform app that:
+- Runs on **iOS and macOS** with one SwiftUI codebase.
+- Stores habits, check-ins, streaks, and settings in **iCloud**.
+- Keeps data synced across all of your personal devices.
+- Supports optional **shared habits** via iCloud/CloudKit sharing.
+
+---
+
+## Recommended Stack
+- **UI**: SwiftUI (`NavigationSplitView`, `List`, `Charts`)
+- **Persistence**: SwiftData (`@Model`, `ModelContainer`)
+- **Cloud Sync**: SwiftData + CloudKit-backed iCloud sync
+- **Sharing**: CloudKit record sharing (`UICloudSharingController` / `NSSharingService` integration)
+- **Notifications**: UserNotifications for reminders
+- **Widgets**: WidgetKit (optional phase 2)
+
+---
+
+## Architecture
+Use a lightweight MVVM setup:
+- `Model`: SwiftData entities (`Habit`, `HabitCheckIn`, `HabitReminder`)
+- `ViewModel/Services`: streak calculation, completion logic, reminder scheduling
+- `Views`: iOS + macOS adaptive SwiftUI views
+
+### Feature modules
+1. **Today**
+   - List habits due today
+   - One-tap completion
+2. **Habit Detail**
+   - Calendar heatmap / completion list
+   - Current streak + best streak
+3. **Analytics**
+   - Completion rate over 7/30/90 days
+4. **Settings**
+   - iCloud sync status
+   - Notification permissions/reminder time
+5. **Sharing**
+   - Invite family/team to shared habits
+
+---
+
+## Data Model (SwiftData)
+
+```swift
+import Foundation
+import SwiftData
+
+@Model
+final class Habit {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var emoji: String
+    var createdAt: Date
+    var targetPerDay: Int
+    var archived: Bool
+
+    @Relationship(deleteRule: .cascade)
+    var checkIns: [HabitCheckIn]
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        emoji: String = "✅",
+        createdAt: Date = .now,
+        targetPerDay: Int = 1,
+        archived: Bool = false,
+        checkIns: [HabitCheckIn] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.emoji = emoji
+        self.createdAt = createdAt
+        self.targetPerDay = targetPerDay
+        self.archived = archived
+        self.checkIns = checkIns
+    }
+}
+
+@Model
+final class HabitCheckIn {
+    @Attribute(.unique) var id: UUID
+    var date: Date
+    var count: Int
+
+    init(id: UUID = UUID(), date: Date, count: Int = 1) {
+        self.id = id
+        self.date = date
+        self.count = count
+    }
+}
+```
+
+---
+
+## Enabling iCloud Sync
+1. In Xcode target settings, enable **iCloud** capability.
+2. Enable **CloudKit** for the same container (e.g. `iCloud.com.yourname.HabitFlow`).
+3. Use a shared `ModelContainer` configured for CloudKit-backed persistence.
+4. Sign in to iCloud on every test device with the same Apple ID.
+5. Use physical devices or macOS app builds for reliable sync testing (simulator CloudKit can be inconsistent).
+
+---
+
+## App Setup Example
+
+```swift
+import SwiftUI
+import SwiftData
+
+@main
+struct HabitFlowApp: App {
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+        }
+        .modelContainer(for: [Habit.self, HabitCheckIn.self])
+    }
+}
+```
+
+> In current Apple SDKs, enabling iCloud + CloudKit capability is the critical step. SwiftData then syncs via CloudKit when configured under the same app container and entitlements.
+
+---
+
+## Streak Calculation Service
+
+```swift
+import Foundation
+
+struct HabitStatsService {
+    static func currentStreak(for dates: [Date], calendar: Calendar = .current) -> Int {
+        let normalized = Set(dates.map { calendar.startOfDay(for: $0) })
+        var streak = 0
+        var cursor = calendar.startOfDay(for: .now)
+
+        while normalized.contains(cursor) {
+            streak += 1
+            guard let previous = calendar.date(byAdding: .day, value: -1, to: cursor) else {
+                break
+            }
+            cursor = previous
+        }
+
+        return streak
+    }
+}
+```
+
+---
+
+## Sharing Data Across People (Optional)
+If you want shared household/team habits (not just your own-device sync), add CloudKit sharing:
+- Store shareable habits in a shared/private CloudKit zone.
+- Create CKShare records for selected habits.
+- Present iOS/macOS share UI.
+- Respect ownership rules for edit/delete.
+
+Start with personal sync first; add collaboration in phase 2.
+
+---
+
+## UX Notes to Match HabitKit Style
+- Clean cards with emoji/icon + habit title + quick check button
+- Strong today focus and immediate feedback animation
+- Visible streak badges and completion rings
+- Low-friction add flow (name + icon + frequency in one sheet)
+- Dark mode polished from day one
+
+---
+
+## Suggested Build Plan
+1. **MVP (Week 1)**
+   - Habit CRUD
+   - Daily check-ins
+   - Current streak
+   - iCloud sync across your devices
+2. **Polish (Week 2)**
+   - Analytics charts
+   - Better animations/haptics
+   - Reminders
+3. **Advanced (Week 3+)**
+   - Shared habits via CloudKit sharing
+   - Widgets + Lock Screen widgets
+   - CSV export/import
+
+---
+
+## Validation Checklist
+- Create habit on iPhone → appears on Mac
+- Mark complete on Mac → appears on iPhone within seconds/minutes
+- Offline check-in queues and syncs later
+- iCloud account sign-out behavior is handled gracefully
+- No duplicate check-ins for the same day
+
+---
+
+## Common Pitfalls
+- Forgetting iCloud/CloudKit entitlements on all targets
+- Testing only in simulator and assuming production behavior
+- Mixing local-only stores with cloud stores accidentally
+- Timezone/day-boundary bugs in streak logic
+


### PR DESCRIPTION
### Motivation
- Provide a practical implementation blueprint to build a HabitKit-like app that runs on iOS and macOS and syncs data across devices via iCloud/CloudKit. 
- Give a clear, Apple-native starting point (SwiftUI + SwiftData) so an Xcode project scaffold and feature work can be generated quickly. 

### Description
- Add `docs/HabitSyncAppBlueprint.md` containing architecture guidance, recommended stack, SwiftData `@Model` examples, app bootstrap snippet, streak calculation service, sharing notes, UX suggestions, and a phased build plan. 
- Update `README.md` to point to the new guide and suggest the next step of generating an Xcode project scaffold. 
- Include concrete code snippets for SwiftData models, a `@main` app example, and a `HabitStatsService` streak function to accelerate implementation. 

### Testing
- Validated file contents with `nl -ba README.md` and `nl -ba docs/HabitSyncAppBlueprint.md` to ensure the new guide and README reference are present. 
- Checked repository working-tree status with `git status --short` to confirm files are staged/created as expected. 
- Created PR metadata via the internal `mcp__make_pr__make_pr` tool to prepare this change for review and the operation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58ccd5ffc8333a28fdfcdb57122c1)